### PR TITLE
Replace node-canvas with @napi-rs/canvas

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,9 @@ WORKDIR /app
 
 COPY . .
 
-RUN bun install --frozen-lockfile
+RUN bun install
 
 RUN bun db:generate
-
-RUN apt update && \
-    apt install -y \
-    libcairo2-dev \
-    libpango1.0-dev \
-    libjpeg-dev \
-    libgif-dev \
-    librsvg2-dev \
-    && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["bun"]
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "bupin-qr-gen",
       "dependencies": {
         "@hono/zod-validator": "^0.4.3",
+        "@napi-rs/canvas": "^0.1.67",
         "@prisma/client": "^6.4.1",
         "canvas": "^3.1.0",
         "hono": "^4.7.2",
@@ -111,6 +112,28 @@
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+
+    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.67", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.67", "@napi-rs/canvas-darwin-arm64": "0.1.67", "@napi-rs/canvas-darwin-x64": "0.1.67", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.67", "@napi-rs/canvas-linux-arm64-gnu": "0.1.67", "@napi-rs/canvas-linux-arm64-musl": "0.1.67", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.67", "@napi-rs/canvas-linux-x64-gnu": "0.1.67", "@napi-rs/canvas-linux-x64-musl": "0.1.67", "@napi-rs/canvas-win32-x64-msvc": "0.1.67" } }, "sha512-VA4Khm/5Kg2bQGx3jXotTC4MloOG8b1Ung80exafUK0k5u6yJmIz3Q2iXeeWZs5weV+LQOEB+CPKsYwEYaGAjw=="],
+
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.67", "", { "os": "android", "cpu": "arm64" }, "sha512-W+3DFG5h0WU8Vqqb3W5fNmm5/TPH5ECZRinQDK4CAKFSUkc4iZcDwrmyFG9sB4KdHazf1mFVHCpEeVMO6Mk6Zg=="],
+
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.67", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xzrv7QboI47yhIHR5P5u/9KGswokuOKLiKSukr1Ku03RRJxP6lGuVtrAZAgdRg7F9FsuF2REf2yK53YVb6pMlA=="],
+
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.67", "", { "os": "darwin", "cpu": "x64" }, "sha512-SNk9lYBr84N0gW8MZ2IrjygFtbFBILr3SEqMdHzHHuph20SQmssFvJGPZwSSCMEyKAvyqhogbmlew0te5Z4w9Q=="],
+
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.67", "", { "os": "linux", "cpu": "arm" }, "sha512-qmBlSvUpl567bzH8tNXi82u5FrL4d0qINqd6K9O7GWGGGFmKMJdrgi2/SW3wwCTxqHBasIDdVWc4KSJfwyaoDQ=="],
+
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.67", "", { "os": "linux", "cpu": "arm64" }, "sha512-k3nAPQefkMeFuJ65Rqdnx92KX1JXQhEKjjWeKsCJB+7sIBgQUWtHo9c3etfVLv5pkWJJDFi/Zc2soNkH3E8dRA=="],
+
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.67", "", { "os": "linux", "cpu": "arm64" }, "sha512-lZwHWR1cCP408l86n3Qbs3X1oFeAYMjJIQvQl1VMZh6wo5PfI+jaZSKBUOd8x44TnVllX9yhLY9unNRztk/sUQ=="],
+
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.67", "", { "os": "linux", "cpu": "none" }, "sha512-PdBC9p6bLHA1W3OdA0vTHj701SB/kioGQ1uCFBRMs5KBCaMLb/H4aNi8uaIUIEvBWnxeAjoNcLU7//q0FxEosw=="],
+
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.67", "", { "os": "linux", "cpu": "x64" }, "sha512-kJJX6eWzjipL/LdKOWCJctc88e5yzuXri8+s0V/lN06OwuLGW62TWS3lvi8qlUrGMOfRGabSWWlB4omhASSB8w=="],
+
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.67", "", { "os": "linux", "cpu": "x64" }, "sha512-jLKiPWGeN6ZzhnaLG7ex7eexsiHJ1mdtPK1qKvETIcu45dApMXyUIHvdL6XWB5gFFtj5ScHzLUxv1vkfPZsoxA=="],
+
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.67", "", { "os": "win32", "cpu": "x64" }, "sha512-K/JmkOFbc4iRZYUqJhj0jwqfHA/wNQEmTiGNsgZ6d59yF/IBNp5T0D5eg3B8ghjI8GxDYCiSJ6DNX8mC3Oh2EQ=="],
 
     "@prisma/client": ["@prisma/client@6.4.1", "", { "peerDependencies": { "prisma": "*", "typescript": ">=5.1.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-A7Mwx44+GVZVexT5e2GF/WcKkEkNNKbgr059xpr5mn+oUm2ZW1svhe+0TRNBwCdzhfIZ+q23jEgsNPvKD9u+6g=="],
 

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "scripts": {
     "dev": "bun run --hot src/index.ts",
     "db:generate": "prisma generate",
+    "build": "bun build --sourcemap ./src/index.ts --outfile ./dist/",
     "compile": "bun build --compile --minify --bytecode --sourcemap ./src/index.ts --outfile ./dist/compiled/main"
   },
   "dependencies": {
     "@hono/zod-validator": "^0.4.3",
+    "@napi-rs/canvas": "^0.1.67",
     "@prisma/client": "^6.4.1",
-    "canvas": "^3.1.0",
     "hono": "^4.7.2",
     "qrcode": "^1.5.4",
     "sharp": "^0.33.5",

--- a/src/handlers/qr.ts
+++ b/src/handlers/qr.ts
@@ -1,5 +1,5 @@
 import { createFactory } from "hono/factory"
-import { QRCodeErrorCorrectionLevel, toCanvas } from "qrcode"
+import { QRCodeErrorCorrectionLevel } from "qrcode"
 import { zValidator } from "@hono/zod-validator"
 import { z } from "zod"
 import { addTextOverlay, compressImage, generateQRCode, getFileName } from "../utils"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { QRCodeErrorCorrectionLevel, toCanvas } from "qrcode"
 import { prisma } from "../lib/db"
 import { InfoUJN, InfoVID } from "../types"
-import { Canvas, createCanvas, registerFont } from "canvas"
+import { Canvas, createCanvas, GlobalFonts } from "@napi-rs/canvas"
 import sharp from "sharp"
 
 /**
@@ -290,7 +290,7 @@ export async function generateQRCode(
  * @param canvas - The canvas element to which the text overlay will be added.
  */
 export function addTextOverlay(canvas: Canvas) {
-  registerFont("./assets/fonts/Poppins-SemiBold.ttf", { family: "Poppins", weight: "600" })
+  GlobalFonts.registerFromPath("./assets/fonts/Poppins-SemiBold.ttf", "Poppins")
 
   const ctx = canvas.getContext("2d")
   const rectMargin = 13


### PR DESCRIPTION
This pull request includes several changes related to Docker configuration, package dependencies, and QR code generation. The most important changes include updates to the `.dockerignore` file, modifications to the `Dockerfile`, and the replacement of [canvas](https://github.com/Automattic/node-canvas) with [@napi-rs/canvas](https://github.com/Brooooooklyn/canvas).

### Docker Configuration:
* Added `node_modules/` and `dist/` directories to `.dockerignore` to prevent them from being included in Docker builds.
* Simplified the `Dockerfile` by removing unnecessary `apt` package installations (required by `canvas`) and updating the `bun install` command to allow for non-frozen lockfiles.

### Package Dependencies:
* Added a new build script to `package.json` for generating source maps and outputting to the `dist/` directory.
* Replaced the `canvas` package with `@napi-rs/canvas` in `package.json` and updated imports accordingly in `src/utils/index.ts`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R6-L11) [[2]](diffhunk://#diff-6147e3c1761df71fd40952dbcbac388a45f80b8c318f367ef41048351a2c0c99L4-R4)

### QR Code Generation:
* Updated the QR code generation utility to use `GlobalFonts.registerFromPath` for font registration.